### PR TITLE
fix: remove duplicate mcp dependency in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ requires-python = ">=3.11"
 dependencies = [
     "mcp[cli]>=1.6.0",
     "requests>=2.31.0",
-    "mcp>=1.0.0",
     "python-dotenv>=1.1.0",
 ]
 keywords = [


### PR DESCRIPTION
## Summary
`pyproject.toml` lists both `mcp[cli]>=1.6.0` and `mcp>=1.0.0` as dependencies. Since `mcp[cli]` is a superset of `mcp`, the second entry is redundant — `mcp[cli]>=1.6.0` already pulls in `mcp` at version 1.6.0 or higher. Having both entries can confuse dependency resolvers and makes the intent of the version constraint unclear.

## How to reproduce
Open `pyproject.toml` and look at the `dependencies` list — `mcp>=1.0.0` appears alongside `mcp[cli]>=1.6.0`, which already satisfies the former.

## Test plan
- Run `uv sync` after the change and confirm the project installs cleanly with no dependency conflicts.
- Run `uv run pytest` to confirm all tests still pass.